### PR TITLE
feat: Combine all the animation widgets into one app

### DIFF
--- a/flutter_animations_pt1/lib/core/helpers.dart
+++ b/flutter_animations_pt1/lib/core/helpers.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+ButtonStyle? style() {
+  return ElevatedButton.styleFrom(
+    foregroundColor: Colors.white,
+    backgroundColor: Colors.black,
+    padding: const EdgeInsets.all(20),
+  );
+}

--- a/flutter_animations_pt1/lib/main.dart
+++ b/flutter_animations_pt1/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_opacity_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_text_style_screen.dart';
 import 'package:flutter_animations_pt1/screens/home_screen.dart';
 
 void main() {
@@ -19,6 +20,7 @@ class AnimationsApp extends StatelessWidget {
         HomeScreen.id : (context) => const HomeScreen(),
         AnimatedContainerScreen.id : (context) => const AnimatedContainerScreen(),
         AnimatedOpacityScreen.id : (context) => const AnimatedOpacityScreen(),
+        AnimatedTextStyleScreen.id : (context) => const AnimatedTextStyleScreen(),
       },
       initialRoute: HomeScreen.id,
     );

--- a/flutter_animations_pt1/lib/main.dart
+++ b/flutter_animations_pt1/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
 import 'package:flutter_animations_pt1/screens/home_screen.dart';
 
 void main() {
@@ -15,6 +16,7 @@ class AnimationsApp extends StatelessWidget {
       title: 'Flutter Demo',
       routes: {
         HomeScreen.id : (context) => const HomeScreen(),
+        AnimatedContainerScreen.id : (context) => const AnimatedContainerScreen(),
       },
       initialRoute: HomeScreen.id,
     );

--- a/flutter_animations_pt1/lib/main.dart
+++ b/flutter_animations_pt1/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_opacity_screen.dart';
 import 'package:flutter_animations_pt1/screens/home_screen.dart';
 
 void main() {
@@ -17,6 +18,7 @@ class AnimationsApp extends StatelessWidget {
       routes: {
         HomeScreen.id : (context) => const HomeScreen(),
         AnimatedContainerScreen.id : (context) => const AnimatedContainerScreen(),
+        AnimatedOpacityScreen.id : (context) => const AnimatedOpacityScreen(),
       },
       initialRoute: HomeScreen.id,
     );

--- a/flutter_animations_pt1/lib/main.dart
+++ b/flutter_animations_pt1/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_list_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_opacity_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_positioned_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_text_style_screen.dart';
 import 'package:flutter_animations_pt1/screens/home_screen.dart';
 
@@ -23,6 +24,7 @@ class AnimationsApp extends StatelessWidget {
         AnimatedOpacityScreen.id : (context) => const AnimatedOpacityScreen(),
         AnimatedTextStyleScreen.id : (context) => const AnimatedTextStyleScreen(),
         AnimatedListScreen.id : (context) => const AnimatedListScreen(),
+        AnimatedPositionedScreen.id : (context) => const AnimatedPositionedScreen(),
       },
       initialRoute: HomeScreen.id,
     );

--- a/flutter_animations_pt1/lib/main.dart
+++ b/flutter_animations_pt1/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_list_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_opacity_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_positioned_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_switcher_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_text_style_screen.dart';
 import 'package:flutter_animations_pt1/screens/home_screen.dart';
 
@@ -25,6 +26,7 @@ class AnimationsApp extends StatelessWidget {
         AnimatedTextStyleScreen.id : (context) => const AnimatedTextStyleScreen(),
         AnimatedListScreen.id : (context) => const AnimatedListScreen(),
         AnimatedPositionedScreen.id : (context) => const AnimatedPositionedScreen(),
+        AnimatedSwitcherScreen.id : (context) => const AnimatedSwitcherScreen(),
       },
       initialRoute: HomeScreen.id,
     );

--- a/flutter_animations_pt1/lib/main.dart
+++ b/flutter_animations_pt1/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_list_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_opacity_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_text_style_screen.dart';
 import 'package:flutter_animations_pt1/screens/home_screen.dart';
@@ -21,6 +22,7 @@ class AnimationsApp extends StatelessWidget {
         AnimatedContainerScreen.id : (context) => const AnimatedContainerScreen(),
         AnimatedOpacityScreen.id : (context) => const AnimatedOpacityScreen(),
         AnimatedTextStyleScreen.id : (context) => const AnimatedTextStyleScreen(),
+        AnimatedListScreen.id : (context) => const AnimatedListScreen(),
       },
       initialRoute: HomeScreen.id,
     );

--- a/flutter_animations_pt1/lib/screens/animated_container_screen.dart
+++ b/flutter_animations_pt1/lib/screens/animated_container_screen.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animations_pt1/core/helpers.dart';
+
+class AnimatedContainerScreen extends StatefulWidget {
+  const AnimatedContainerScreen({super.key});
+
+  static const id = 'Animated Container';
+
+  @override
+  State<AnimatedContainerScreen> createState() =>
+      _AnimatedContainerScreenState();
+}
+
+class _AnimatedContainerScreenState extends State<AnimatedContainerScreen> {
+  bool toggle = false;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter Animations'),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AnimatedContainer(
+              duration: const Duration(
+                seconds: 1,
+              ),
+              color: toggle ? Colors.blueGrey : Colors.deepOrange,
+              width: toggle ? 100 : 200,
+              height: toggle ? 100 : 200,
+            ),
+            const SizedBox(height: 20,),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  toggle = !toggle;
+                });
+              },
+              style: style(),
+              child: const Text(
+                'Animate',
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_animations_pt1/lib/screens/animated_list_screen.dart
+++ b/flutter_animations_pt1/lib/screens/animated_list_screen.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+class AnimatedListScreen extends StatefulWidget {
+  const AnimatedListScreen({super.key});
+
+  static const id = 'Animated List';
+  @override
+  State<AnimatedListScreen> createState() => _AnimatedListScreenState();
+}
+
+class _AnimatedListScreenState extends State<AnimatedListScreen> {
+  final GlobalKey<AnimatedListState> _key = GlobalKey();
+  List<int> items = [];
+
+  void _addItem() {
+    items.insert(0, items.isEmpty ? 0 : items[0] + 1);
+    _key.currentState!.insertItem(
+      0,
+      duration: const Duration(
+        milliseconds: 500,
+      ),
+    );
+  }
+
+  void _removeItem(int idx) {
+    _key.currentState!.removeItem(
+      idx,
+      (context, animation) {
+        return SizeTransition(
+          sizeFactor: animation,
+          child: const Card(
+            color: Colors.red,
+            child: ListTile(
+              title: Text('Removing...'),
+            ),
+          ),
+        );
+      },
+      duration: const Duration(
+        milliseconds: 500,
+      ),
+    );
+    items.removeAt(idx);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter Animations'),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: AnimatedList(
+          key: _key,
+          itemBuilder: (context, index, animation) {
+            return SizeTransition(
+              sizeFactor: animation,
+              child: Card(
+                color: Colors.teal,
+                child: ListTile(
+                  title: Text("item ${items[index]}"),
+                  trailing: IconButton(
+                    onPressed: () {
+                      _removeItem(index);
+                    },
+                    icon: const Icon(
+                      Icons.delete,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addItem,
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        child: const Icon(
+          Icons.add,
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_animations_pt1/lib/screens/animated_opacity_screen.dart
+++ b/flutter_animations_pt1/lib/screens/animated_opacity_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animations_pt1/core/helpers.dart';
+
+class AnimatedOpacityScreen extends StatefulWidget {
+  const AnimatedOpacityScreen({super.key});
+
+  static const id = 'Animated Opacity';
+
+  @override
+  State<AnimatedOpacityScreen> createState() => _AnimatedOpacityScreenState();
+}
+
+class _AnimatedOpacityScreenState extends State<AnimatedOpacityScreen> {
+  bool toggle = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter Animations'),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AnimatedOpacity(
+              opacity: toggle ? 0 : 1,
+              duration: const Duration(
+                seconds: 2,
+              ),
+              curve: Curves.easeInOut,
+              child: Image.network(
+                'https://img-cdn.pixlr.com/image-generator/history/65bb506dcb310754719cf81f/ede935de-1138-4f66-8ed7-44bd16efc709/medium.webp',
+              ),
+            ),
+            const SizedBox(height: 20,),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  toggle = !toggle;
+                });
+              },
+              style: style(),
+              child: const Text(
+                'Animate',
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_animations_pt1/lib/screens/animated_positioned_screen.dart
+++ b/flutter_animations_pt1/lib/screens/animated_positioned_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animations_pt1/core/helpers.dart';
+
+class AnimatedPositionedScreen extends StatefulWidget {
+  const AnimatedPositionedScreen({super.key});
+
+  static const id = 'Animated Positioned';
+  @override
+  State<AnimatedPositionedScreen> createState() =>
+      _AnimatedPositionedScreenState();
+}
+
+class _AnimatedPositionedScreenState extends State<AnimatedPositionedScreen> {
+  bool toggle = false;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter Animations'),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Column(
+        children: [
+          Stack(
+            children: [
+              Container(
+                color: Colors.amber,
+                height: 550,
+                width: 500,
+              ),
+              AnimatedPositioned(
+                duration: const Duration(seconds: 2),
+                top: toggle ? 300 : 30,
+                left: toggle ? 300 : 30,
+                height: toggle ? 200 : 100,
+                width: toggle ? 100 : 200,
+                child: Container(
+                  color: Colors.black,
+                ),
+              )
+            ],
+          ),
+          const SizedBox(
+            height: 20,
+          ),
+          ElevatedButton(
+            onPressed: () {
+              setState(() {
+                toggle = !toggle;
+              });
+            },
+            style: style(),
+            child: const Text(
+              'Animate',
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_animations_pt1/lib/screens/animated_switcher_screen.dart
+++ b/flutter_animations_pt1/lib/screens/animated_switcher_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_animations_pt1/core/helpers.dart';
+
+class AnimatedSwitcherScreen extends StatefulWidget {
+  const AnimatedSwitcherScreen({super.key});
+
+  static const id = 'Animated Switcher';
+  @override
+  State<AnimatedSwitcherScreen> createState() => _AnimatedSwitcherScreenState();
+}
+
+class _AnimatedSwitcherScreenState extends State<AnimatedSwitcherScreen> {
+  bool toggle = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter Animations'),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 500),
+              transitionBuilder: (child, animation) {
+                return RotationTransition(
+                  turns: animation,
+                  child: child,
+                );
+              },
+              child: toggle
+                  ? Container(
+                      key: const ValueKey(1),
+                      height: 100,
+                      width: 200,
+                      color: Colors.blue,
+                    )
+                  : Container(
+                      key: const ValueKey(2),
+                      height: 200,
+                      width: 100,
+                      color: Colors.black,
+                    ),
+            ),
+            const SizedBox(
+              height: 20,
+            ),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  toggle = !toggle;
+                });
+              },
+              style: style(),
+              child: const Text(
+                'Animate',
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_animations_pt1/lib/screens/animated_text_style_screen.dart
+++ b/flutter_animations_pt1/lib/screens/animated_text_style_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animations_pt1/core/helpers.dart';
+
+class AnimatedTextStyleScreen extends StatefulWidget {
+  const AnimatedTextStyleScreen({super.key});
+
+  static const id = 'Animated Default TextStyle';
+
+  @override
+  State<AnimatedTextStyleScreen> createState() => _AnimatedTextStyleScreenState();
+}
+
+class _AnimatedTextStyleScreenState extends State<AnimatedTextStyleScreen> {
+  bool toggle = false;
+  
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter Animations'),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AnimatedDefaultTextStyle(
+              duration: const Duration(
+                seconds: 1,
+              ),
+              style: TextStyle(
+                color: toggle ? Colors.black : Colors.red,
+                fontSize: toggle ? 30 : 20,
+                fontWeight: toggle ? FontWeight.bold : FontWeight.normal,
+              ),
+              child: const Text(
+                'Some text is animated here',
+              ),
+            ),
+            const SizedBox(height: 20,),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  toggle = !toggle;
+                });
+              },
+              style: style(),
+              child: const Text(
+                'Animate',
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_animations_pt1/lib/screens/home_screen.dart
+++ b/flutter_animations_pt1/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_list_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_opacity_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_positioned_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_switcher_screen.dart';
 import 'package:flutter_animations_pt1/screens/animated_text_style_screen.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -19,7 +20,7 @@ class HomeScreen extends StatelessWidget {
       AnimatedTextStyleScreen.id,
       AnimatedListScreen.id,
       AnimatedPositionedScreen.id,
-      'Animated Switcher',
+      AnimatedSwitcherScreen.id,
     ];
     return Scaffold(
       appBar: AppBar(

--- a/flutter_animations_pt1/lib/screens/home_screen.dart
+++ b/flutter_animations_pt1/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animations_pt1/core/helpers.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -52,10 +53,4 @@ class HomeScreen extends StatelessWidget {
   }
 }
 
-ButtonStyle? style() {
-  return ElevatedButton.styleFrom(
-    foregroundColor: Colors.white,
-    backgroundColor: Colors.black,
-    padding: const EdgeInsets.all(20),
-  );
-}
+

--- a/flutter_animations_pt1/lib/screens/home_screen.dart
+++ b/flutter_animations_pt1/lib/screens/home_screen.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animations_pt1/core/helpers.dart';
+import 'package:flutter_animations_pt1/screens/animated_container_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_list_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_opacity_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_positioned_screen.dart';
+import 'package:flutter_animations_pt1/screens/animated_text_style_screen.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -9,11 +14,11 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     List<String> animations = [
-      'Animated Container',
-      'Animated Opacity',
-      'Animated Default TextStyle',
-      'Animated List',
-      'Animated Positioned',
+      AnimatedContainerScreen.id,
+      AnimatedOpacityScreen.id,
+      AnimatedTextStyleScreen.id,
+      AnimatedListScreen.id,
+      AnimatedPositionedScreen.id,
       'Animated Switcher',
     ];
     return Scaffold(


### PR DESCRIPTION
# App Structure

- The app contains the **Home Screen** which has a list of buttons.
- Each button navigate to a new screen showing the corresponding animation widgets.

<img width=200; src= 'https://github.com/user-attachments/assets/d53b79c2-4785-4cf4-809a-4f73c39cdd2a'>

- Each Screen has a button that toggle the state of the animation 
<img width=200; src= 'https://github.com/user-attachments/assets/e99451ba-5577-4539-a1a7-8cb0966465fc'>
<img width=200; src= 'https://github.com/user-attachments/assets/92060c94-7e08-45a2-aba2-175170f06278'>
<img width=200; src= 'https://github.com/user-attachments/assets/1d8cad74-e962-45c1-ae82-b7570feb358f'>
<img width=200; src= 'https://github.com/user-attachments/assets/ed16726e-ecbe-43dd-ad9d-dbad1174f719'>
<img width=200; src= 'https://github.com/user-attachments/assets/9c7630a2-1a23-4504-b341-7f9d0b4147d3'>
<img width=200; src= 'https://github.com/user-attachments/assets/aac1696e-2e17-495c-9f0d-3dd2dec39e43'>
